### PR TITLE
fix: update scraper selectors and consent handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     restart: unless-stopped # Restart policy
     working_dir: /app # Set working directory
     networks:
-      - shark
+      - caddy_default
+    volumes:
+      - .:/app
     # Tmpfs mounts to keep temporary files in RAM
     tmpfs:
       - /tmp:size=512M
@@ -27,7 +29,7 @@ services:
           memory: 3G
 
 # Create the external network first with:
-# docker network create shark
+# docker network create caddy_default
 networks:
-  shark:
+  caddy_default:
     external: true


### PR DESCRIPTION
## Summary
This PR fixes the scraping functionality which was breaking due to changes in Google Maps' DOM structure and consent forms.

## Changes
- **`gmaps_scraper_server/scraper.py`**:
  - Updated the consent form XPath to handle `input` type buttons (previously only matched `button` elements).
  - Added robust fallback logic for detecting the results feed if the primary `[role="feed"]` selector fails.
  - Improved waiting strategies for smoother navigation.
- **`docker-compose.yml`**:
  - Added a volume mount (`.:/app`) to enable hot-reloading during development.

## Verification
Tested locally with query `coffee